### PR TITLE
build: cleanup and reorganization

### DIFF
--- a/build-aux/flatpak/io.github.lainsce.Khronos.Devel.json
+++ b/build-aux/flatpak/io.github.lainsce.Khronos.Devel.json
@@ -11,7 +11,7 @@
         "--share=ipc",
         "--device=dri"
     ],
-    "desktop-file-name-suffix" : " (Devel)",
+    "desktop-file-name-suffix" : " (Development)",
     "cleanup" : [
         "/cache",
         "/man",
@@ -86,13 +86,12 @@
             "name" : "khronos",
             "buildsystem" : "meson",
             "config-opts" : [
-                "-Dprofile=development"
+                "-Ddevelopment=true"
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/lainsce/khronos.git",
-                    "branch" : "main"
+                    "type" : "dir",
+                    "path" : "../../"
                 }
             ]
         }

--- a/data/io.github.lainsce.Khronos.desktop.in
+++ b/data/io.github.lainsce.Khronos.desktop.in
@@ -2,7 +2,7 @@
 Name=Khronos
 Comment=Track each task time in a simple inobtrusive way
 Exec=io.github.lainsce.Khronos
-Icon=io.github.lainsce.Khronos
+Icon=@app_id@
 Keywords=Plot;Planning;Time Tracking;
 Terminal=false
 Type=Application

--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-    <id>io.github.lainsce.Khronos</id>
+    <id>@app_id@</id>
     <metadata_license>CC0</metadata_license>
     <project_license>GPL-3.0+</project_license>
     <name translatable="no">Khronos</name>
@@ -40,7 +40,7 @@
     <custom>
       <value key="GnomeSoftware::key-colors">[(145, 65, 172)]</value>
     </custom>
-    <translation type="gettext">io.github.lainsce.Khronos</translation>
+    <translation type="gettext">@app_id@</translation>
     <releases>
         <release version="3.6.7" date="2022-01-05">
             <description>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,23 +1,54 @@
+conf = configuration_data()
+conf.set('app_id', app_id)
+
 install_data(
-    meson.project_name() + '.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+  meson.project_name() + '.gschema.xml',
+  install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
 )
 
-i18n.merge_file(
-    input: meson.project_name() + '.desktop.in',
-    output: meson.project_name() + '.desktop',
-    po_dir: '../po',
-    type: 'desktop',
-    install: true,
-    install_dir: join_paths(get_option('datadir'), 'applications')
+desktop_conf = configure_file(
+  input: meson.project_name() + '.desktop.in',
+  output: '@0@.desktop.in'.format(app_id),
+  configuration: conf,
 )
 
-i18n.merge_file(
-    input: meson.project_name() + '.metainfo.xml.in',
-    output: meson.project_name() + '.metainfo.xml',
-    po_dir: '../po',
-    install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+desktop_file = i18n.merge_file(
+  input: desktop_conf,
+  output: '@0@.desktop'.format(app_id),
+  po_dir: '../po',
+  type: 'desktop',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'applications')
 )
+
+# Validate Desktop file
+desktop_file_validate = find_program('desktop-file-validate', required: false)
+if desktop_file_validate.found()
+  test('validate-desktop', desktop_file_validate,
+    args: [desktop_file]
+  )
+endif
+
+appstream_conf = configure_file(
+  input: meson.project_name() + '.metainfo.xml.in',
+  output: '@0@.metainfo.xml.in'.format(app_id),
+  configuration: conf,
+)
+
+appstream_file = i18n.merge_file(
+  input: appstream_conf,
+  output: '@0@.metainfo.xml'.format(app_id),
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
+)
+
+#Validate Appstream file
+appstream_file_validate = find_program('appstream-util', required: false)
+if appstream_file_validate.found()
+  test('validate-appstream', appstream_file_validate,
+    args: ['validate', '--nonet', appstream_file]
+  )
+endif
 
 subdir('icons')

--- a/meson.build
+++ b/meson.build
@@ -8,78 +8,75 @@ add_project_arguments([
 	language: 'vala',
 )
 
-if get_option('profile') == 'development'
-  name_prefix = '(Development) '
-  profile = '.Devel'
+if get_option('development')
+  app_id = 'io.github.lainsce.Khronos.Devel'
+  name_suffix = ' (Development)'
 else
-  name_prefix = ''
-  profile = ''
+  app_id = 'io.github.lainsce.Khronos'
+  name_suffix = ''
 endif
-
-app_id = '@0@@1@'.format(meson.project_name(), profile)
 
 conf = configuration_data()
 conf.set_quoted('APP_ID', app_id)
-conf.set_quoted('NAME_PREFIX', name_prefix)
-conf.set_quoted('PROFILE', profile)
+conf.set_quoted('NAME_SUFFIX', name_suffix)
 conf.set_quoted('VERSION', meson.project_version())
-conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
-conf.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir')))
-conf.set_quoted('GNOMELOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set_quoted('GETTEXT_PACKAGE', app_id)
+conf.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+conf.set10('DEVELOPMENT', get_option('development'))
 configure_file(output: 'config.h', configuration: conf)
 config_h_dir = include_directories('.')
 
 
 add_project_arguments(
-    '-include', 'config.h',
-    '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name()),
-    language: 'c'
+  '-include', 'config.h',
+  '-DGETTEXT_PACKAGE="@0@"'.format(app_id),
+  language: 'c'
 )
 
 asresources = gnome.compile_resources(
-    'as-resources', 'data/io.github.lainsce.Khronos.gresource.xml',
-    source_dir: 'data',
-    c_name: 'as'
+  'as-resources', 'data/io.github.lainsce.Khronos.gresource.xml',
+  source_dir: 'data',
+  c_name: 'as'
 )
 
-sources = files(
-    'src/Application.vala',
-    'src/MainWindow.vala',
-    'src/Models/Log.vala',
-    'src/Repositories/LogRepository.vala',
-    'src/Views/LogListView.vala',
-    'src/Views/View.vala',
-    'src/ViewModels/LogViewModel.vala',
-    'src/Utils/FileUtils.vala',
-    'src/Utils/MiscUtils.vala',
-    'src/Utils/ThreadUtils.vala',
-    'src/Utils/ObservableList.vala',
-    'src/Services/SettingsManager.vala',
-    'src/Services/MigrationManager.vala',
-    'src/Services/FileManager.vala',
-    'src/Services/Dialog.vala',
-    'src/Widgets/LogRowContent.vala',
-)
+sources = [
+  'src/Application.vala',
+  'src/MainWindow.vala',
+  'src/Models/Log.vala',
+  'src/Repositories/LogRepository.vala',
+  'src/Views/LogListView.vala',
+  'src/Views/View.vala',
+  'src/ViewModels/LogViewModel.vala',
+  'src/Utils/FileUtils.vala',
+  'src/Utils/MiscUtils.vala',
+  'src/Utils/ThreadUtils.vala',
+  'src/Utils/ObservableList.vala',
+  'src/Services/SettingsManager.vala',
+  'src/Services/MigrationManager.vala',
+  'src/Services/FileManager.vala',
+  'src/Services/Dialog.vala',
+  'src/Widgets/LogRowContent.vala',
+]
 
 dependencies = [
-    dependency('gio-2.0'),
-    dependency('gtk4'),
-    dependency('glib-2.0'),
-    dependency('gobject-2.0'),
-    dependency('gee-0.8'),
-    dependency('libadwaita-1'),
-    dependency('gmodule-2.0'),
-    dependency('json-glib-1.0'),
-    meson.get_compiler('c').find_library('m', required: true)
+  dependency('gio-2.0'),
+  dependency('gtk4'),
+  dependency('glib-2.0'),
+  dependency('gobject-2.0'),
+  dependency('gee-0.8'),
+  dependency('libadwaita-1'),
+  dependency('gmodule-2.0'),
+  dependency('json-glib-1.0'),
+  meson.get_compiler('c').find_library('m', required: true)
 ]
 
 executable(
-    meson.project_name(),
-    sources,
-    asresources,
-    dependencies: dependencies,
-    vala_args: [meson.source_root() + '/src/Config.vapi'],
-    install : true
+  meson.project_name(),
+  sources,
+  asresources,
+  dependencies: dependencies,
+  vala_args: [meson.source_root() + '/src/Config.vapi'],
+  install : true
 )
 
 subdir('data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,10 +1,1 @@
-option(
-  'profile',
-  type: 'combo',
-  choices: [
-    'default',
-    'development',
-  ],
-  value: 'default',
-  description: 'The build profile for Khronos. One of "default" or "development".'
-)
+option('development', type: 'boolean', value: false, description: 'If this is a development build')

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,1 @@
-i18n.gettext(meson.project_name(), preset: 'glib')
+i18n.gettext(app_id, preset: 'glib')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,7 +26,7 @@ public class Khronos.Application : Adw.Application {
         Object (application_id: Config.APP_ID);
     }
     public static int main (string[] args) {
-        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.GNOMELOCALEDIR);
+        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
         Intl.textdomain (Config.GETTEXT_PACKAGE);
 
         var app = new Khronos.Application ();

--- a/src/Config.vapi
+++ b/src/Config.vapi
@@ -1,10 +1,9 @@
 [CCode (cprefix = "", lower_case_cprefix = "", cheader_filename = "config.h")]
 namespace Config {
-    public const string VERSION;
-    public const string PROFILE;
-    public const string NAME_PREFIX;
-    public const string GETTEXT_PACKAGE;
-    public const string GNOMELOCALEDIR;
-    public const string DATADIR;
     public const string APP_ID;
+    public const string NAME_SUFFIX;
+    public const string VERSION;
+    public const string GETTEXT_PACKAGE;
+    public const string LOCALEDIR;
+    public const bool DEVELOPMENT;
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -77,7 +77,7 @@ namespace Khronos {
                 application: application,
                 app: application,
                 view_model: view_model,
-                icon_name: "io.github.lainsce.Khronos",
+                icon_name: Config.APP_ID,
                 title: "Khronos"
             );
 
@@ -143,7 +143,7 @@ namespace Khronos {
                 timer_button.activate ();
             });
 
-            if (Config.PROFILE == ".Devel")
+            if (Config.DEVELOPMENT)
                 add_css_class ("devel");
 
             this.set_size_request (360, 360);
@@ -212,9 +212,8 @@ namespace Khronos {
                 null
             };
 
-            var program_name = Config.NAME_PREFIX + ("Khronos");
             Gtk.show_about_dialog (this,
-                                   "program-name", program_name,
+                                   "program-name", "Khronos" + Config.NAME_SUFFIX,
                                    "logo-icon-name", Config.APP_ID,
                                    "version", Config.VERSION,
                                    "comments", _("Track each task\'s time in a simple inobtrusive way."),


### PR DESCRIPTION
These changes have been tested with both manifests, stable and devel, as well as manually builded without regressions/warnings whatsoever.

- Reorganized `data/meson.build` and added metainfo and desktop files validation.
- Name prefix is now a suffix.
- Reverted manifest's source type to 'dir' as it breaks CI in forks.
- Meson build option is now a bool to avoid writing '.Devel' to files where necessary.
- Removed `DATADIR` as it is unused.
- Fixed CI.