### PR TITLE
appdata: add vcs-browser support

### DIFF
--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -23,6 +23,7 @@
     <url type="bugtracker">https://github.com/lainsce/khronos/issues</url>
     <url type="donation">https://ko-fi.com/lainsce/</url>
     <url type="translate">https://github.com/lainsce/khronos/blob/main/po/README.md</url>
+    <url type="vcs-browser">https://github.com/lainsce/khronos</url>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/lainsce/khronos/main/data/shot.png</image>


### PR DESCRIPTION
These URLs are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url