### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -11,6 +11,16 @@
             <li>Quit anytime with the shortcut Ctrl + Q</li>
         </ul>
     </description>
+    <categories>
+        <category>GNOME</category>
+        <category>GTK</category>
+        <category>Office</category>
+    </categories>
+    <keywords>
+        <keyword>Plot</keyword>
+        <keyword>Planning</keyword>
+        <keyword>Time Tracking</keyword>
+    </keywords>    
     <provides>
         <binary>io.github.lainsce.Khronos</binary>
     </provides>
@@ -42,6 +52,7 @@
       <value key="GnomeSoftware::key-colors">[(145, 65, 172)]</value>
     </custom>
     <translation type="gettext">@app_id@</translation>
+    <launchable type="desktop-id">io.github.lainsce.Khronos.desktop</launchable>
     <releases>
         <release version="4.0.1" date="2023-10-11">
             <description>

--- a/data/meson.build
+++ b/data/meson.build
@@ -39,10 +39,10 @@ appstream_file = i18n.merge_file(
 )
 
 #Validate Appstream file
-appstream_file_validate = find_program('appstream-util', required: false)
+appstream_file_validate = find_program('appstreamcli', required: false)
 if appstream_file_validate.found()
   test('validate-appstream', appstream_file_validate,
-    args: ['validate', '--nonet', appstream_file]
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 

--- a/po/io.github.lainsce.Khronos.pot
+++ b/po/io.github.lainsce.Khronos.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-15 12:34+0300\n"
+"POT-Creation-Date: 2023-10-29 16:03+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,11 +31,23 @@ msgstr ""
 msgid "Quit anytime with the shortcut Ctrl + Q"
 msgstr ""
 
-#: data/io.github.lainsce.Khronos.metainfo.xml.in:48
+#: data/io.github.lainsce.Khronos.metainfo.xml.in:20
+msgid "Plot"
+msgstr ""
+
+#: data/io.github.lainsce.Khronos.metainfo.xml.in:21
+msgid "Planning"
+msgstr ""
+
+#: data/io.github.lainsce.Khronos.metainfo.xml.in:22
+msgid "Time Tracking"
+msgstr ""
+
+#: data/io.github.lainsce.Khronos.metainfo.xml.in:59
 msgid "Release: Day 2"
 msgstr ""
 
-#: data/io.github.lainsce.Khronos.metainfo.xml.in:50
+#: data/io.github.lainsce.Khronos.metainfo.xml.in:61
 msgid "Changed: Overall refinements to match the updated looks of GNOME apps."
 msgstr ""
 


### PR DESCRIPTION
### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Add categories, keywords and launchable tags

These tags may improve Software Center accessibility.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-categories

### po: Update the POT file

Add new strings.
