### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -11,16 +11,6 @@
             <li>Quit anytime with the shortcut Ctrl + Q</li>
         </ul>
     </description>
-    <categories>
-        <category>GNOME</category>
-        <category>GTK</category>
-        <category>Office</category>
-    </categories>
-    <keywords>
-        <keyword>Plot</keyword>
-        <keyword>Planning</keyword>
-        <keyword>Time Tracking</keyword>
-    </keywords>    
     <provides>
         <binary>io.github.lainsce.Khronos</binary>
     </provides>

--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -18,7 +18,11 @@
       <kudo>ModernToolkit</kudo>
       <kudo>HiDpiIcon</kudo>
     </kudos>
+    <!-- developer_name tag deprecated with Appstream 1.0 -->
     <developer_name translatable="no">Lains</developer_name>
+    <developer id="github.com">
+      <name translatable="no">Lains</name>
+    </developer>
     <url type="homepage">https://github.com/lainsce/khronos/</url>
     <url type="bugtracker">https://github.com/lainsce/khronos/issues</url>
     <url type="donation">https://www.patreon.com/lainsce</url>

--- a/data/meson.build
+++ b/data/meson.build
@@ -39,10 +39,12 @@ appstream_file = i18n.merge_file(
 )
 
 #Validate Appstream file
-appstream_file_validate = find_program('appstreamcli', required: false)
-if appstream_file_validate.found()
-  test('validate-appstream', appstream_file_validate,
-    args: ['validate', '--no-net', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('validate-appstream',
+    appstreamcli,
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 

--- a/io.github.lainsce.Khronos.Devel.json
+++ b/io.github.lainsce.Khronos.Devel.json
@@ -30,6 +30,7 @@
         {
             "name" : "khronos",
             "buildsystem" : "meson",
+            "run-tests" : true,
             "config-opts" : [
                 "-Ddevelopment=true"
             ],


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli arguments
- Activate meson tests on flatpak manifest

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories