### PR TITLE
Update developer ID

### DIFF
--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -20,7 +20,7 @@
     </kudos>
     <!-- developer_name tag deprecated with Appstream 1.0 -->
     <developer_name translatable="no">Lains</developer_name>
-    <developer id="github.com">
+    <developer id="io.github.lainsce">
       <name translatable="no">Lains</name>
     </developer>
     <url type="homepage">https://github.com/lainsce/khronos/</url>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer