### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.lainsce.Khronos.metainfo.xml.in
+++ b/data/io.github.lainsce.Khronos.metainfo.xml.in
@@ -3,7 +3,7 @@
     <id>@app_id@</id>
     <metadata_license>CC0</metadata_license>
     <project_license>GPL-3.0+</project_license>
-    <name translatable="no">Khronos</name>
+    <name translate="no">Khronos</name>
     <summary>Log the time it took to do tasks</summary>
     <description>
         <p>Start logging any task's time to completion, with the ability to stop the timer at any moment, with notifications for longer task sessions.</p>
@@ -19,9 +19,9 @@
       <kudo>HiDpiIcon</kudo>
     </kudos>
     <!-- developer_name tag deprecated with Appstream 1.0 -->
-    <developer_name translatable="no">Lains</developer_name>
+    <developer_name translate="no">Lains</developer_name>
     <developer id="io.github.lainsce">
-      <name translatable="no">Lains</name>
+      <name translate="no">Lains</name>
     </developer>
     <url type="homepage">https://github.com/lainsce/khronos/</url>
     <url type="bugtracker">https://github.com/lainsce/khronos/issues</url>
@@ -57,7 +57,7 @@
             </description>
         </release>
         <release version="4.0.0" date="2023-09-20">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Day</p>
                 <ul>
                     <li>Changed: Overall refinements to match the updated looks of GNOME apps.</li>
@@ -65,7 +65,7 @@
             </description>
         </release>
         <release version="3.7.1" date="2022-07-01">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Hour</p>
                 <ul>
                     <li>Changed: UI is now pure Adwaita following the inclusion of Khronos in GNOME Circle.</li>
@@ -73,7 +73,7 @@
             </description>
         </release>
         <release version="3.7.0" date="2022-04-20">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Minute</p>
                 <ul>
                     <li>Changed: UI now follows my own style that complements that of Adwaita, called Solo.</li>
@@ -81,7 +81,7 @@
             </description>
         </release>
         <release version="3.6.8" date="2022-01-05">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Second</p>
                 <ul>
                     <li>Changed: The UI colors, they are now way less in your face yet are still colored. The Logs are now stylized like cards.</li>
@@ -89,7 +89,7 @@
             </description>
         </release>
         <release version="3.6.7" date="2022-01-05">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Nanosecond</p>
                 <ul>
                     <li>Removed: each log's delete button, as they would be accidentally clicked and would remove the log.</li>
@@ -97,7 +97,7 @@
             </description>
         </release>
         <release version="3.6.6" date="2021-12-03">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Leap Year</p>
                 <ul>
                     <li>Added: Logs now have tags! Add tags in the new entry below log name, by specifying them with colons, like this: "tag1:tag2:tag3".</li>
@@ -105,7 +105,7 @@
             </description>
         </release>
         <release version="3.6.5" date="2021-12-01">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Tick Tock Clock</p>
                 <ul>
                     <li>Changed: UI now sports an experimental design.</li>
@@ -114,7 +114,7 @@
             </description>
         </release>
         <release version="3.5.0" date="2021-02-09">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: UI Refreshments</p>
                 <ul>
                     <li>Changed: The UI is now with a better layout.</li>
@@ -122,7 +122,7 @@
             </description>
         </release>
         <release version="3.0.0" date="2021-01-29">
-            <description translatable="no">
+            <description translate="no">
                 <p>Release: Port to GTK4</p>
                 <ul>
                     <li>Changed: Rewritten for GTK4.</li>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html